### PR TITLE
Add newline before and after a markdown list

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -153,7 +153,7 @@ class MarkdownConverter(object):
             el = el.parent
         if nested:
             text = '\n' + self.indent(text, 1)
-        return text
+        return '\n' + text + '\n'
 
     convert_ul = convert_list
     convert_ol = convert_list


### PR DESCRIPTION
Fixes matthewwithanm#5 as well as an issue where `<p>foo<p><ul><li>bar</li></ul>` gets converted to `foo * bar` which is not correct